### PR TITLE
Add `Revenue` Logger

### DIFF
--- a/Sources/LogSubsystem.swift
+++ b/Sources/LogSubsystem.swift
@@ -27,7 +27,10 @@ public enum LogSubsystem {
     
     /// Metering or paywall related logs.
     case metering
-    
+
+    /// Growth and Value features.
+    case revenue
+
     public func loggerFunc(category: String) -> Logger {
         switch self {
         case .Core:
@@ -40,6 +43,8 @@ public enum LogSubsystem {
             return Logger(subsystem: "Experiments", category: category)
         case .metering:
             return Logger(subsystem: "Metering", category: category)
+        case .revenue:
+            return Logger(subsystem: "Growth", category: category)
         }
     }
 }

--- a/Sources/LogSubsystem.swift
+++ b/Sources/LogSubsystem.swift
@@ -25,10 +25,10 @@ public enum LogSubsystem {
     /// Experimental features or A/B testing.
     case experiments
     
-    /// Metering or paywall related logs.
+    /// Metering specific related logs.
     case metering
 
-    /// Growth and Value features.
+    /// Growth and Value features. e.g Storekit and Acquisition related features.
     case revenue
 
     public func loggerFunc(category: String) -> Logger {
@@ -44,7 +44,7 @@ public enum LogSubsystem {
         case .metering:
             return Logger(subsystem: "Metering", category: category)
         case .revenue:
-            return Logger(subsystem: "Growth", category: category)
+            return Logger(subsystem: "Revenue", category: category)
         }
     }
 }


### PR DESCRIPTION
## What does this change?

Adds a case for Revenue i.e. Supporter Revenue, this is different from Metering. Revenue has broken down into Growth and Value separate streams.
