### PR TITLE
Improvements!

### DIFF
--- a/Sources/Examples/LogExample.swift
+++ b/Sources/Examples/LogExample.swift
@@ -1,6 +1,5 @@
 //
 //  LogExample.swift
-//  NewLogger
 //
 //  Created by Usman Nazir on 03/10/2023.
 //
@@ -176,4 +175,44 @@ func logLevels() {
     Log.console("Three", .warning, .personalisation)
     Log.console("Four", .error, .personalisation, "My Guardian")
     print("ABC")
+}
+
+func infoLogs() {
+    Log.info("One")
+    Log.info("Two", .Core)
+    Log.info("Three", .named(system: "Custom Module"))
+}
+
+func warningLogs() {
+    Log.warning("One")
+    Log.warning("Two", .Core)
+    Log.warning("Three", .named(system: "Custom Module"))
+}
+
+func errorLogs() {
+    Log.error("One")
+    Log.error("Two", .Core)
+    Log.error("Three", .named(system: "Custom Module"))
+}
+
+func customLogs() {
+    Log.info("One", .named(system: "Custom Module 1"))
+    Log.warning("Two", .named(system: "Custom Module 2"))
+    Log.error("Three", .named(system: "Custom Module 3"))
+}
+
+func logUsingNames() {
+    Log.info("One", .named(system: "Something"))
+    Log.warning("Two", .named("Also Something"))
+}
+
+func logUsingEnum() {
+    // An enum that can be logged to Qalam
+    enum SomeLoggableEnum: String, QalamLoggable {
+        case one
+        case two
+    }
+    
+    Log.info("One", .module(SomeLoggableEnum.one))
+    Log.info("Two", .module(SomeLoggableEnum.two))
 }

--- a/Sources/Log.swift
+++ b/Sources/Log.swift
@@ -75,7 +75,7 @@ public class Log {
     public static func info(_ obj: Any, _ module: LogSubsystem = .Core) {
         guard isEnabled else { return }
         switch module {
-        case .module(let system):
+        case .named(let system):
             logToModule(obj, logger: module.loggerFunc(category: system.capitalized), type: .info)
         default:
             logToModule(obj, logger: module.loggerFunc(category: "Default"), type: .info)
@@ -90,7 +90,7 @@ public class Log {
     public static func warning(_ obj: Any, _ module: LogSubsystem = .Core) {
         guard isEnabled else { return }
         switch module {
-        case .module(let system):
+        case .named(let system):
             logToModule(obj, logger: module.loggerFunc(category: system.capitalized), type: .warning)
         default:
             logToModule(obj, logger: module.loggerFunc(category: "Default"), type: .warning)
@@ -105,7 +105,7 @@ public class Log {
     public static func error(_ obj: Any, _ module: LogSubsystem = .Core) {
         guard isEnabled else { return }
         switch module {
-        case .module(let system):
+        case .named(let system):
             logToModule(obj, logger: module.loggerFunc(category: system.capitalized), type: .error)
         default:
             logToModule(obj, logger: module.loggerFunc(category: "Default"), type: .error)

--- a/Sources/Log.swift
+++ b/Sources/Log.swift
@@ -77,6 +77,8 @@ public class Log {
         switch module {
         case .named(let system):
             logToModule(obj, logger: module.loggerFunc(category: system.capitalized), type: .info)
+        case .module(let systemLoggable):
+            logToModule(obj, logger: module.loggerFunc(category: systemLoggable.rawValue.capitalized), type: .info)
         default:
             logToModule(obj, logger: module.loggerFunc(category: "Default"), type: .info)
         }
@@ -92,6 +94,8 @@ public class Log {
         switch module {
         case .named(let system):
             logToModule(obj, logger: module.loggerFunc(category: system.capitalized), type: .warning)
+        case .module(let systemLoggable):
+            logToModule(obj, logger: module.loggerFunc(category: systemLoggable.rawValue.capitalized), type: .warning)
         default:
             logToModule(obj, logger: module.loggerFunc(category: "Default"), type: .warning)
         }
@@ -107,6 +111,8 @@ public class Log {
         switch module {
         case .named(let system):
             logToModule(obj, logger: module.loggerFunc(category: system.capitalized), type: .error)
+        case .module(let systemLoggable):
+            logToModule(obj, logger: module.loggerFunc(category: systemLoggable.rawValue.capitalized), type: .error)
         default:
             logToModule(obj, logger: module.loggerFunc(category: "Default"), type: .error)
         }

--- a/Sources/Log.swift
+++ b/Sources/Log.swift
@@ -75,10 +75,6 @@ public class Log {
     ///   - type: The severity or type of the log.
     private static func logToModule(_ obj: Any, logger: Logger, type: LogType) {
         if let object = obj as? CustomStringConvertible {
-            if obj is Error {
-                logToType("\(object.description)", logger: logger, type: .error)
-                return
-            }
             logToType(object.description, logger: logger, type: type)
         } else if obj is Int ||
                     obj is String ||

--- a/Sources/Log.swift
+++ b/Sources/Log.swift
@@ -67,6 +67,51 @@ public class Log {
         return module.loggerFunc(category: "Default")
     }
     
+    /// Logs an informational message to the specified logging subsystem.
+    ///
+    /// - Parameters:
+    ///   - obj: The object or message to log. Can be any type conforming to `CustomStringConvertible`.
+    ///   - module: The subsystem or module to associate with this log entry. Defaults to `.Core`.
+    public static func info(_ obj: Any, _ module: LogSubsystem = .Core) {
+        guard isEnabled else { return }
+        switch module {
+        case .module(let system):
+            logToModule(obj, logger: module.loggerFunc(category: system.capitalized), type: .info)
+        default:
+            logToModule(obj, logger: module.loggerFunc(category: "Default"), type: .info)
+        }
+    }
+
+    /// Logs a warning message to the specified logging subsystem.
+    ///
+    /// - Parameters:
+    ///   - obj: The object or message to log. Can be any type conforming to `CustomStringConvertible`.
+    ///   - module: The subsystem or module to associate with this log entry. Defaults to `.Core`.
+    public static func warning(_ obj: Any, _ module: LogSubsystem = .Core) {
+        guard isEnabled else { return }
+        switch module {
+        case .module(let system):
+            logToModule(obj, logger: module.loggerFunc(category: system.capitalized), type: .warning)
+        default:
+            logToModule(obj, logger: module.loggerFunc(category: "Default"), type: .warning)
+        }
+    }
+
+    /// Logs an error message to the specified logging subsystem.
+    ///
+    /// - Parameters:
+    ///   - obj: The object or message to log. Can be any type conforming to `CustomStringConvertible` or `Error`.
+    ///   - module: The subsystem or module to associate with this log entry. Defaults to `.Core`.
+    public static func error(_ obj: Any, _ module: LogSubsystem = .Core) {
+        guard isEnabled else { return }
+        switch module {
+        case .module(let system):
+            logToModule(obj, logger: module.loggerFunc(category: system.capitalized), type: .error)
+        default:
+            logToModule(obj, logger: module.loggerFunc(category: "Default"), type: .error)
+        }
+    }
+    
     /// Logs the object to the specified module.
     ///
     /// - Parameters:

--- a/Sources/LogSubsystem.swift
+++ b/Sources/LogSubsystem.swift
@@ -37,11 +37,14 @@ public enum LogSubsystem {
     /// Deeplinking related logs, related to the deeplink manager.
     case deeplinking
     
-    // Puzzles features.
+    /// Puzzles features.
     case puzzles
     
     /// Case to adapt any other sub system
-    case module(system: String)
+    case named(system: String)
+    
+    /// Case to adapt any other Loggable enum to Qalam
+    case module(systemLoggable: any QalamLoggable)
 
     public func loggerFunc(category: String) -> Logger {
         switch self {
@@ -63,8 +66,29 @@ public enum LogSubsystem {
             return Logger(subsystem: "Deeplinking", category: category)
         case .puzzles:
             return Logger(subsystem: "Puzzles", category: category)
-        case .module(let system):
+        case .named(let system):
             return Logger(subsystem: "\(system.capitalized)", category: category)
+        case .module(let systemLoggable):
+            return Logger(subsystem: "\(systemLoggable.rawValue.capitalized)", category: category)
         }
+    }
+}
+
+// Helper/Convenience functions
+extension LogSubsystem {
+    
+    /// Creates a dynamic logging subsystem by name.
+    ///
+    /// Example:
+    /// ```swift
+    /// let custom = LogSubsystem.named("Usman")
+    /// ```
+    public static func named(_ name: String) -> LogSubsystem {
+        .named(system: name)
+    }
+    
+    /// Creates a dynamic logging subsystem by loggable enum.
+    public static func module(_ module: any QalamLoggable) -> LogSubsystem {
+        .module(systemLoggable: module)
     }
 }

--- a/Sources/LogSubsystem.swift
+++ b/Sources/LogSubsystem.swift
@@ -36,6 +36,12 @@ public enum LogSubsystem {
 
     /// Deeplinking related logs, related to the deeplink manager.
     case deeplinking
+    
+    // Puzzles features.
+    case puzzles
+    
+    /// Case to adapt any other sub system
+    case module(system: String)
 
     public func loggerFunc(category: String) -> Logger {
         switch self {
@@ -50,11 +56,15 @@ public enum LogSubsystem {
         case .metering:
             return Logger(subsystem: "Metering", category: category)
         case .revenue:
-            return Logger(subsystem: "Revenue", category: category)
+            return Logger(subsystem: "Supporter Revenue", category: category)
         case .nophan:
             return Logger(subsystem: "Nophan", category: category)
         case .deeplinking:
             return Logger(subsystem: "Deeplinking", category: category)
+        case .puzzles:
+            return Logger(subsystem: "Puzzles", category: category)
+        case .module(let system):
+            return Logger(subsystem: "\(system.capitalized)", category: category)
         }
     }
 }

--- a/Sources/LogSubsystem.swift
+++ b/Sources/LogSubsystem.swift
@@ -81,7 +81,7 @@ extension LogSubsystem {
     ///
     /// Example:
     /// ```swift
-    /// let custom = LogSubsystem.named("Usman")
+    /// let custom = Log.info("Hello!", .named("Usman"))
     /// ```
     public static func named(_ name: String) -> LogSubsystem {
         .named(system: name)

--- a/Sources/Loggable.swift
+++ b/Sources/Loggable.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+public protocol QalamLoggable: RawRepresentable, CaseIterable where RawValue == String {}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR brings some fixes and much needed improvements to Qalam for ease of use.

Fixes:
- The `logToModule` function was incorrectly assuming some String values to be errors. That logic has been taken out, so Qalam will not automatically set anything to be an error and will always priritise using the log type provided by the developer.

Improvements:

- Three new convenience functions have been added for logging: .info(), .warning() and .error(). These can be used like:

```swift
Log.info("One")
Log.warning("Two")
Log.error("Three")
```

- Log Subsystem has been updated to have 3 new cases: `.puzzles`, `.named(String)` and `.module(any QalamLoggable)`. Two of these are dynamic so the logger can be used for any other cases as needed.

These can be used like:

```swift
Log.info("Something", .puzzles)
Log.info("Something Else", .named("Fronts"))
Log.info("Another Thing", .module(.platform))
```

- A protocol, QalamLoggable, has been added that can be used to adapt more Enums outside the framework to be easily integrated and used with Qalam.

Example:
```swift
// An enum that can be logged to Qalam
    enum SomeLoggableEnum: String, QalamLoggable {
        case one
        case two
    }
    
    Log.info("One", .module(SomeLoggableEnum.one))
    Log.info("Two", .module(SomeLoggableEnum.two))
```

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Nothing crucial to test, this PR has just introduced some convenience functions and functionalities. 

To test, try loading this framework onto a sample project and test the examples given in the `LogExample.swift` file.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Hopefully, this makes it easier to use and adapt Qalam in the future.
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

These are just improvements and nothing has been taken out so it should not break anything.
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<img width="312" height="296" alt="image" src="https://github.com/user-attachments/assets/1cab3e90-62a5-4352-adde-3bc9f47b229d" />


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
